### PR TITLE
Update OSC message format 2

### DIFF
--- a/oribotic-instrument-atmega32u4/ORICORD.cpp
+++ b/oribotic-instrument-atmega32u4/ORICORD.cpp
@@ -818,8 +818,8 @@ void setupMPR()
 
   void setPanelGroup(OSCMessage &msg)
   {
-    if (msg.isInt(0)) {
-      bool val = msg.getInt(0);
+    if (isNumber(msg, 0)) {
+      bool val = getNumber(msg, 0);
       // send feedback to PD
       if (val == 1)
       {

--- a/oribotic-instrument-atmega32u4/ORICORD.cpp
+++ b/oribotic-instrument-atmega32u4/ORICORD.cpp
@@ -514,9 +514,9 @@ void setBendSingleKey(uint8_t key, char param[4])
     orikeys[key].bendHI = val;
   }
   #if OSC == 1
-    sprintf(chan, "/key/%s/%d", param, key);
+    sprintf(chan, "/key/%s", param);
     //Serial.println(chan);
-    sendOSC(chan, val);
+    sendOSC(chan, key, val);
   #else
     if (mode==MODE_SERIAL_DEBUG || mode==MODE_SERIAL_DEBUG_RAW)
     {

--- a/oribotic-instrument-atmega32u4/comms.midi.cpp
+++ b/oribotic-instrument-atmega32u4/comms.midi.cpp
@@ -78,7 +78,7 @@
              }
              break;
             case 110:               // set mode
-              mode = value;
+              setMode(value);
               controlChange(0, 110, value); // send feedback on same channel
               // Serial.println(mode);
               break;
@@ -159,9 +159,22 @@
     Serial.println(note);
   }
 
+  void setMode(uint8_t mode)
+  {
+    if (value > MAXMODE)
+    {
+      return;
+    }
+    mode = value;
+  }
+
   void setMIDIRoot(uint8_t newroot)
   {
-  rootNote = newroot;
+    if (val < 0 || val > 127)
+    {
+      return;
+    }
+    rootNote = newroot;
   }
 
 #if SETUP_FUNCTIONS == 1

--- a/oribotic-instrument-atmega32u4/comms.osc.cpp
+++ b/oribotic-instrument-atmega32u4/comms.osc.cpp
@@ -83,12 +83,10 @@ void dispatchGetNotes(OSCMessage &msg)
 void getNotes()
 {
     int note;
-    char chan[10];
     for (int i = 0; i < PINCOUNT; i++)
     {
       note = orikeys[i].note + rootNote;
-      sprintf(chan, "/n/%d", i);
-      sendOSC(chan, note);
+      sendOSC("/n", (uint8_t)i, note);
       delay(20);
     }
 }
@@ -98,6 +96,10 @@ void setRoot(OSCMessage &msg)
     if (isNumber(msg, 0))
     {
       int val = getNumber(msg, 0);
+      if (val < 0 || val > 127)
+      {
+        return;
+      }
       rootNote = val;
       // send feedback to PD
       sendOSC("/set/root", val);
@@ -109,8 +111,10 @@ void setScale(OSCMessage &msg)
 {
   if (isNumber(msg, 0))
   {
-    uint8_t val = getNumber(msg, 0);
-    changeScale(val);
+    int val = getNumber(msg, 0);
+    val = changeScale((uint8_t)val);
+    // send feedback to PD
+    sendOSC("/set/scale", val);
   }
 }
 
@@ -120,6 +124,10 @@ void setMode(OSCMessage &msg)
     if (isNumber(msg, 0))
     {
       int val = getNumber(msg, 0);
+      if( val < 0 || val > MAXMODE)
+      {
+        return;
+      }
       mode = val;
       // send feedback to PD
       sendOSC("/set/mode", val);

--- a/oribotic-instrument-atmega32u4/comms.osc.cpp
+++ b/oribotic-instrument-atmega32u4/comms.osc.cpp
@@ -65,13 +65,11 @@ void sendOSC(char msg_str[20], uint8_t key, uint16_t arg1, uint16_t arg2 = 3333)
     msg.empty();            // free space occupied by message
 }
 
-// returns true if arg at index is an int or a float
 bool isNumber(OSCMessage &msg, int arg)
 {
   return msg.isInt(arg) || msg.isFloat(arg);
 }
 
-// returns int or float value of arg at index as an int
 int getNumber(OSCMessage &msg, int arg)
 {
   return (msg.isFloat(arg) ? (int)msg.getFloat(arg) : msg.getInt(arg));

--- a/oribotic-instrument-atmega32u4/comms.osc.h
+++ b/oribotic-instrument-atmega32u4/comms.osc.h
@@ -26,6 +26,12 @@
 
 // --------------------------------------------------------------------    FUNCTION PROTOTYPES
 
+// returns true if arg at index is an int or a float
+bool isNumber(OSCMessage &msg, int arg);
+
+// returns int or float value of arg at index as an int
+int getNumber(OSCMessage &msg, int arg);
+
 void rxOSC();
 //void rawOSC(uint8_t key);
 //void playOSC(uint8_t key);

--- a/oribotic-instrument-atmega32u4/instrument_config.h
+++ b/oribotic-instrument-atmega32u4/instrument_config.h
@@ -38,9 +38,9 @@ extern uint8_t intervaldelay;
 #define MODE_NORMALISED 3 // works for midi and osc
 #define MODE_RAW_PLUS_NORMALISED 4 // only works on osc 
 #define MODE_TOUCH_PLAY 5 // works on midi and osc - default mode
-#define MODE_SOFT_VELOCITY 6 // works on midi and osc - default mode
-// #define MODE_TOUCH_PLAY 6
+#define MODE_SOFT_VELOCITY 6 // works on midi and osc
 //#define MODE_SERIAL_DEBUG_BYTES 5 // no longer used 
+#define MAXMODE 6 // max allowed mode index
 
 #if ORIGAMI==YOSHIMURA
     #include "instrument_Y8.h"

--- a/oribotic-instrument-atmega32u4/music.scales.cpp
+++ b/oribotic-instrument-atmega32u4/music.scales.cpp
@@ -26,7 +26,13 @@ void generateMidiScale (uint8_t index, uint8_t root)
     scale[0] = root;
 
     bool tonalstep;
-    uint8_t scaleMap = availableScales[index].tones;
+    uint8_t scaleMap;
+
+    if (index > MAXSCALE)
+    {
+      return;
+    }
+    scaleMap = availableScales[index].tones;
     // remember 0b00000001 (the ONE is bit 0)
     // so we skip bit 0
 
@@ -46,11 +52,15 @@ void generateMidiScale (uint8_t index, uint8_t root)
     scale[7] = root + 12;
 }
 
-void changeScale (uint8_t value)
+uint8_t changeScale(uint8_t value)
 {
+  if (value <= MAXSCALE)
+  {
     // set global value
     scaleIndex = value;
     generateMidiScale(scaleIndex, rootNote);
+  }
+  return scaleIndex;
 }
 
 void changeRoot(boolean direction)

--- a/oribotic-instrument-atmega32u4/music.scales.h
+++ b/oribotic-instrument-atmega32u4/music.scales.h
@@ -3,6 +3,8 @@
 #ifndef MUSIC_SCALES_H
 #define MUSIC_SCALES_H
 
+#define MAXSCALE 8 // max allowed scale index
+
 struct scaleTones
 {
   char title[5];
@@ -14,6 +16,6 @@ extern uint8_t scale[8];
 
 extern struct scaleTones availableScales[8];
 void generateMidiScale (uint8_t index, uint8_t root);
-void changeScale (uint8_t value);
+uint8_t changeScale (uint8_t value); // returns new value if set
 
 #endif // MUSIC_SCALES_H


### PR DESCRIPTION
Further firmware updates:

* /setPanelGroup now handles float args
* declare `isNumber()` and `getNumber()` in comms.osc.h header (required for above)
* send /key and /n with id as arg
* set /setScale now handles float args and sends feedback
* check range when setting mode, scale, & root